### PR TITLE
Adds Json as a form of TestResponse

### DIFF
--- a/hspec-snap.cabal
+++ b/hspec-snap.cabal
@@ -38,6 +38,7 @@ Test-Suite test-hspec-snap
     hs-source-dirs: spec
     main-is: Main.hs
     build-depends:     base >= 4.6 && < 4.8
+                     , aeson >= 0.6 && < 1
                      , bytestring >= 0.9 && < 0.11
                      , containers >= 0.4 && < 0.6
                      , digestive-functors >= 0.7 && < 0.8
@@ -48,6 +49,7 @@ Test-Suite test-hspec-snap
                      , mtl >= 2 && < 3
                      , snap >= 0.13 && < 0.14
                      , snap-core >= 0.9 && < 0.10
+                     , snap-extras > 0.4 && < 1
                      , text >= 0.11 && < 1.2
                      , transformers >= 0.3 && < 0.5
                      , directory >= 1.2 && < 1.3


### PR DESCRIPTION
Adds a `Json` `TestResponse` by looking at the `content-type` header. Keeps the body as a lazy `ByteString` for future `decode`ing. I considered `decode`ing the body immediately into a `Maybe Value` in order to add some `shouldBeEmptyObject` type predicates, but it didn't seem to add any real value versus letting the user `decode` directly into their expected `FromJSON` instance.

Defaults the anything without `content-type=application/json` to `Html`. I dunno [how far you want to take this](http://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types), but at least adding a JSON type would be nice.
