### PR TITLE
Lens dep and removing snap extras

### DIFF
--- a/hspec-snap.cabal
+++ b/hspec-snap.cabal
@@ -17,41 +17,41 @@ source-repository head
 library
   exposed-modules:
         Test.Hspec.Snap
-  hs-source-dirs: src
-  build-depends:       base               >= 4.6 && < 4.8
-                     , bytestring         >= 0.9 && < 0.11
-                     , containers         >= 0.4 && < 0.6
-                     , digestive-functors >= 0.7 && < 0.8
-                     , hspec              >= 2.0 && < 2.2
-                     , hspec-core         >= 2.0 && < 2.2
-                     , hxt                >= 9.3 && < 9.4
-                     , HandsomeSoup       >= 0.3 && < 0.4
-                     , lens               >= 3.10 && < 5
-                     , mtl                >= 2 && < 3
-                     , snap               >= 0.13 && < 0.14
-                     , snap-core          >= 0.9 && < 0.10
-                     , text               >= 0.11 && < 1.3
-                     , transformers       >= 0.3 && < 0.5
+  hs-source-dirs:  src
+  build-depends:   base                     >= 4.6      && < 4.8
+                 , bytestring               >= 0.9      && < 0.11
+                 , containers               >= 0.4      && < 0.6
+                 , digestive-functors       >= 0.7      && < 0.8
+                 , hspec                    >= 2.0      && < 2.2
+                 , hspec-core               >= 2.0      && < 2.2
+                 , hxt                      >= 9.3      && < 9.4
+                 , HandsomeSoup             >= 0.3      && < 0.4
+                 , lens                     >= 3.10     && < 5
+                 , mtl                      >= 2        && < 3
+                 , snap                     >= 0.13     && < 0.14
+                 , snap-core                >= 0.9      && < 0.10
+                 , text                     >= 0.11     && < 1.3
+                 , transformers             >= 0.3      && < 0.5
 
 
 Test-Suite test-hspec-snap
-    type:       exitcode-stdio-1.0
-    hs-source-dirs: spec
-    main-is: Main.hs
-    build-depends:     base               >= 4.6 && < 4.8
-                     , aeson              >= 0.6 && < 1
-                     , bytestring         >= 0.9 && < 0.11
-                     , containers         >= 0.4 && < 0.6
-                     , digestive-functors >= 0.7 && < 0.8
-                     , hspec              >= 2.0 && < 2.2
-                     , hspec-core         >= 2.0 && < 2.2
-                     , hxt                >= 9.3 && < 9.4
-                     , HandsomeSoup       >= 0.3 && < 0.4
-                     , lens               >= 3.10 && < 5
-                     , mtl                >= 2 && < 3
-                     , snap               >= 0.13 && < 0.14
-                     , snap-core          >= 0.9 && < 0.10
-                     , text               >= 0.11 && < 1.3
-                     , transformers       >= 0.3 && < 0.5
-                     , directory          >= 1.2 && < 1.3
-    build-depends: hspec-snap == 0.3.2.3
+  type:            exitcode-stdio-1.0
+  hs-source-dirs:  spec
+  main-is:         Main.hs
+  build-depends:   base                     >= 4.6      && < 4.8
+                 , aeson                    >= 0.6      && < 1
+                 , bytestring               >= 0.9      && < 0.11
+                 , containers               >= 0.4      && < 0.6
+                 , digestive-functors       >= 0.7      && < 0.8
+                 , hspec                    >= 2.0      && < 2.2
+                 , hspec-core               >= 2.0      && < 2.2
+                 , hxt                      >= 9.3      && < 9.4
+                 , HandsomeSoup             >= 0.3      && < 0.4
+                 , lens                     >= 3.10     && < 5
+                 , mtl                      >= 2        && < 3
+                 , snap                     >= 0.13     && < 0.14
+                 , snap-core                >= 0.9      && < 0.10
+                 , text                     >= 0.11     && < 1.3
+                 , transformers             >= 0.3      && < 0.5
+                 , directory                >= 1.2      && < 1.3
+  build-depends:   hspec-snap               == 0.3.2.3

--- a/hspec-snap.cabal
+++ b/hspec-snap.cabal
@@ -26,7 +26,7 @@ library
                      , hspec-core         >= 2.0 && < 2.2
                      , hxt                >= 9.3 && < 9.4
                      , HandsomeSoup       >= 0.3 && < 0.4
-                     , lens               >= 3.10 && < 4.6
+                     , lens               >= 3.10 && < 5
                      , mtl                >= 2 && < 3
                      , snap               >= 0.13 && < 0.14
                      , snap-core          >= 0.9 && < 0.10
@@ -47,7 +47,7 @@ Test-Suite test-hspec-snap
                      , hspec-core         >= 2.0 && < 2.2
                      , hxt                >= 9.3 && < 9.4
                      , HandsomeSoup       >= 0.3 && < 0.4
-                     , lens               >= 3.10 && < 4.6
+                     , lens               >= 3.10 && < 5
                      , mtl                >= 2 && < 3
                      , snap               >= 0.13 && < 0.14
                      , snap-core          >= 0.9 && < 0.10

--- a/hspec-snap.cabal
+++ b/hspec-snap.cabal
@@ -51,7 +51,6 @@ Test-Suite test-hspec-snap
                      , mtl                >= 2 && < 3
                      , snap               >= 0.13 && < 0.14
                      , snap-core          >= 0.9 && < 0.10
-                     , snap-extras        > 0.4 && < 1
                      , text               >= 0.11 && < 1.3
                      , transformers       >= 0.3 && < 0.5
                      , directory          >= 1.2 && < 1.3

--- a/hspec-snap.cabal
+++ b/hspec-snap.cabal
@@ -47,7 +47,7 @@ Test-Suite test-hspec-snap
                      , hspec-core         >= 2.0 && < 2.2
                      , hxt                >= 9.3 && < 9.4
                      , HandsomeSoup       >= 0.3 && < 0.4
-                     , lens               >= 3.10 && < 4.5
+                     , lens               >= 3.10 && < 4.6
                      , mtl                >= 2 && < 3
                      , snap               >= 0.13 && < 0.14
                      , snap-core          >= 0.9 && < 0.10

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -44,7 +44,6 @@ import           Snap                                        (Handler,
                                                               writeBS,
                                                               writeText)
 import qualified Snap
-import           Snap.Extras                                 (writeJSON)
 import           Snap.Snaplet.Session
 import           Snap.Snaplet.Session.Backends.CookieSession
 import           System.Directory                            (doesFileExist,
@@ -54,6 +53,8 @@ import           Text.Digestive
 
 import           Test.Hspec
 import           Test.Hspec.Snap
+
+import           Utils                                       (writeJSON)
 
 ----------------------------------------------------------
 -- Section 1: Example application used for testing.     --

--- a/spec/Utils.hs
+++ b/spec/Utils.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings         #-}
+
+{-|
+Module      : Utils
+Description : Helpers for testing
+
+Currently just copypasta from snap-extras to avoid dependency conflicts
+-}
+module Utils where
+
+import           Data.Aeson      (encode, ToJSON)
+
+import           Snap.Core       (modifyResponse, setHeader, writeLBS
+                                 ,MonadSnap)
+
+
+-------------------------------------------------------------------------------
+-- | Set MIME to 'application/json' and write given object into
+-- 'Response' body.
+writeJSON :: (MonadSnap m, ToJSON a) => a -> m ()
+writeJSON a = do
+  jsonResponse
+  writeLBS . encode $ a
+
+
+-------------------------------------------------------------------------------
+-- | Mark response as 'application/json'
+jsonResponse :: MonadSnap m => m ()
+jsonResponse = modifyResponse $ setHeader "Content-Type" "application/json"


### PR DESCRIPTION
Bumps lens dependency to < 5 to avoid the need to release a new hspec-snap version for every minor version. The few places hspec-snap uses lens explicitly seem pretty stable and the dependency enforced by snap{,-core,etc.} will keep it in line, I think.

This also removes the snap-extras dependency and copies the two functions needed from it to a new Utils module in spec/ - snap-extras dependencies are updated very rarely and include many things not really needed for most projects. A blaze-builder dependency was giving me problems when trying to do the bump above. It also builds (with --enable-tests) quite a bit faster without it.