### PR TITLE
Upgrade to hspec 2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 *~
-dist
-.cabal-sandbox
-cabal.sandbox.config
+.stack-work

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.3.3.1 - 2015-8-23 - Widen hspec bound (allow 2.2).
+
 0.3.3.0 - 2015-6-5 - Add postJson helper.
 
 0.3.2.9 - 2015-5-22 - Typo in previous release (dependency in test suite was wrong).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-0.3.3.1 - 2015-8-23 - Widen hspec bound (allow 2.2).
+0.3.3.1 - 2015-9-8 - Upgrade to hspec 2.2 (this is breaking, so we require it).
 
 0.3.3.0 - 2015-6-5 - Add postJson helper.
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,19 @@
-machine:
-  ghc:
-    version: 7.10.1
+dependencies:
+  cache_directories:
+    - "~/.stack"
+    - "~/hspec-snap/.stack-work"
+  pre:
+    - wget https://github.com/commercialhaskell/stack/releases/download/v0.1.3.1/stack-0.1.3.1-x86_64-linux.gz -O /tmp/stack.gz
+    - gunzip /tmp/stack.gz && chmod +x /tmp/stack
+    - sudo mv /tmp/stack /usr/bin/stack
+  override:
+    - stack setup --resolver lts-2.17
+    - stack setup --resolver lts-3.4
+    - stack build --resolver lts-2.17
+    - stack build --resolver lts-3.4
+
+
+test:
+  override:
+    - stack test --resolver lts-2.17
+    - stack test --resolver lts-3.4

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   ghc:
-    version: 7.8.3
+    version: 7.10.1

--- a/hspec-snap.cabal
+++ b/hspec-snap.cabal
@@ -23,8 +23,8 @@ library
                  , bytestring               >= 0.9      && < 0.11
                  , containers               >= 0.4      && < 0.6
                  , digestive-functors       >= 0.7      && < 0.9
-                 , hspec                    >= 2.0      && < 2.3
-                 , hspec-core               >= 2.0      && < 2.3
+                 , hspec                    >= 2.2      && < 2.3
+                 , hspec-core               >= 2.2      && < 2.3
                  , hxt                      >= 9.3      && < 9.4
                  , HandsomeSoup             >= 0.3      && < 0.5
                  , lens                     >= 3.10     && < 5
@@ -45,8 +45,8 @@ Test-Suite test-hspec-snap
                  , bytestring               >= 0.9      && < 0.11
                  , containers               >= 0.4      && < 0.6
                  , digestive-functors       >= 0.7      && < 0.9
-                 , hspec                    >= 2.0      && < 2.3
-                 , hspec-core               >= 2.0      && < 2.3
+                 , hspec                    >= 2.2      && < 2.3
+                 , hspec-core               >= 2.2      && < 2.3
                  , hxt                      >= 9.3      && < 9.4
                  , HandsomeSoup             >= 0.3      && < 0.5
                  , lens                     >= 3.10     && < 5

--- a/hspec-snap.cabal
+++ b/hspec-snap.cabal
@@ -1,5 +1,5 @@
 name:                hspec-snap
-version:             0.3.3.0
+version:             0.3.3.1
 synopsis:            A library for testing with Hspec and the Snap Web Framework
 homepage:            https://github.com/dbp/hspec-snap
 license:             BSD3
@@ -23,8 +23,8 @@ library
                  , bytestring               >= 0.9      && < 0.11
                  , containers               >= 0.4      && < 0.6
                  , digestive-functors       >= 0.7      && < 0.9
-                 , hspec                    >= 2.0      && < 2.2
-                 , hspec-core               >= 2.0      && < 2.2
+                 , hspec                    >= 2.0      && < 2.3
+                 , hspec-core               >= 2.0      && < 2.3
                  , hxt                      >= 9.3      && < 9.4
                  , HandsomeSoup             >= 0.3      && < 0.5
                  , lens                     >= 3.10     && < 5
@@ -45,8 +45,8 @@ Test-Suite test-hspec-snap
                  , bytestring               >= 0.9      && < 0.11
                  , containers               >= 0.4      && < 0.6
                  , digestive-functors       >= 0.7      && < 0.9
-                 , hspec                    >= 2.0      && < 2.2
-                 , hspec-core               >= 2.0      && < 2.2
+                 , hspec                    >= 2.0      && < 2.3
+                 , hspec-core               >= 2.0      && < 2.3
                  , hxt                      >= 9.3      && < 9.4
                  , HandsomeSoup             >= 0.3      && < 0.5
                  , lens                     >= 3.10     && < 5
@@ -56,4 +56,4 @@ Test-Suite test-hspec-snap
                  , text                     >= 0.11     && < 1.3
                  , transformers             >= 0.3      && < 0.5
                  , directory                >= 1.2      && < 1.3
-  build-depends:   hspec-snap               == 0.3.3.0
+  build-depends:   hspec-snap               == 0.3.3.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,9 @@
+flags: {}
+packages:
+- '.'
+extra-deps:
+- hspec-2.2.0
+- hspec-core-2.2.0
+- hspec-expectations-0.7.2
+- hspec-discover-2.2.0
+resolver: lts-2.17


### PR DESCRIPTION
This is a breaking change, so we can't support < 2.2 and >= 2.2 at once. 

This PR also switches to using stack to build, and in CI tests with lts-2.17 (GHC 7.8) and lts-3.4 (GHC 7.10).