### PR TITLE
Add response codes to response values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *~
 .stack-work
+.cabal-sandbox/
+cabal.sandbox.config
+dist/

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -177,7 +177,8 @@ tests store' mvar =
         post "/params" (params [("q", "hello")]) >>= shouldHaveText "POST hello"
         post "/params" (params [("r", "hello")]) >>= shouldNotHaveText "hello"
       it "should post json" $ do
-        Json raw <- postJson "/postJson" exampleObj
+        resp@(Json _ raw) <- postJson "/postJson" exampleObj
+        should200 resp
         Just (ExampleObject 43 "foo!") `shouldEqual` decode raw
       it "should not match <html> on PUT request" $
         put "/test" M.empty >>= shouldNotHaveText "<html>"
@@ -201,9 +202,9 @@ tests store' mvar =
         get "/redirect" >>= shouldNot300To "/redirect"
         get "/test" >>= shouldNot300To "/redirect"
       it "differentiates between response content types" $ do
-        Json raw <- get "/json"
+        Json _ raw <- get "/json"
         Just exampleObj `shouldEqual` decode raw
-        Html doc <- get "/test"
+        Html _ doc <- get "/test"
         doc `shouldEqual` html
     describe "stateful changes" $ do
       let isE = use mv >>= \m -> liftIO $ isEmptyMVar m


### PR DESCRIPTION
We've talked about this before, but I'm open to other ways. Long term maybe keep the `Snap.Test.Response` in `TestResponse` so that everything can be dug out if needed?