### PR TITLE
Support hspec 2.5

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,10 +10,13 @@ dependencies:
   override:
     - stack setup --resolver lts-6.33
     - stack setup --resolver lts-8.14
+    - stack setup --resolver nightly-2017-09-17
     - stack build --resolver lts-6.33
     - stack build --resolver lts-8.14
+    - stack build --resolver nightly-2017-09-17
 
 test:
   override:
     - stack test hspec-snap --resolver lts-6.33
     - stack test hspec-snap --resolver lts-8.14
+    - stack test hspec-snap --resolver nightly-2017-09-17

--- a/circle.yml
+++ b/circle.yml
@@ -3,10 +3,10 @@ dependencies:
     - "~/.stack"
     - "~/hspec-snap/.stack-work"
   pre:
-    - wget https://github.com/commercialhaskell/stack/releases/download/v1.4.0/stack-1.4.0-linux-x86_64.tar.gz -O /tmp/stack.tar.gz
+    - wget https://github.com/commercialhaskell/stack/releases/download/v1.5.1/stack-1.5.1-linux-x86_64.tar.gz -O /tmp/stack.tar.gz
     - mkdir /tmp/stack/
     - tar -xvzf /tmp/stack.tar.gz -C /tmp/stack/
-    - sudo mv /tmp/stack/stack-1.4.0-linux-x86_64/stack /usr/bin/stack
+    - sudo mv /tmp/stack/stack-1.5.1-linux-x86_64/stack /usr/bin/stack
   override:
     - stack setup --resolver lts-6.33
     - stack setup --resolver lts-8.14

--- a/hspec-snap.cabal
+++ b/hspec-snap.cabal
@@ -41,20 +41,20 @@ Test-Suite test-hspec-snap
   hs-source-dirs:  spec
   main-is:         Main.hs
   other-modules:   Utils
-  build-depends:   base                     >= 4.6      && < 4.10
-                 , aeson                    >= 0.6      && < 1.3
-                 , bytestring               >= 0.9      && < 0.11
-                 , containers               >= 0.4      && < 0.6
-                 , digestive-functors       >= 0.7      && < 0.9
-                 , hspec                    >= 2.2      && < 2.5
-                 , hspec-core               >= 2.2      && < 2.5
-                 , hxt                      >= 9.3      && < 9.4
-                 , HandsomeSoup             >= 0.3      && < 0.5
-                 , lens                     >= 3.10     && < 5
-                 , mtl                      >= 2        && < 3
-                 , snap                     >= 1.0      && < 1.1
-                 , snap-core                >= 1.0      && < 1.1
-                 , text                     >= 0.11     && < 1.3
-                 , transformers             >= 0.3      && < 0.6
+  build-depends:   base
+                 , aeson
+                 , bytestring
+                 , containers
+                 , digestive-functors
                  , directory                >= 1.2      && < 1.4
-  build-depends:   hspec-snap               == 1.0.0.2
+                 , hspec
+                 , hspec-core
+                 , hxt
+                 , HandsomeSoup
+                 , lens
+                 , mtl
+                 , snap
+                 , snap-core
+                 , text
+                 , transformers
+  build-depends:   hspec-snap

--- a/hspec-snap.cabal
+++ b/hspec-snap.cabal
@@ -18,20 +18,20 @@ library
   exposed-modules:
         Test.Hspec.Snap
   hs-source-dirs:  src
-  build-depends:   base                     >= 4.6      && < 4.11
-                 , aeson                    >= 0.6      && < 1.3
+  build-depends:   base                     >= 4.6      && < 4.12
+                 , aeson                    >= 0.6      && < 1.4
                  , bytestring               >= 0.9      && < 0.11
                  , containers               >= 0.4      && < 0.6
                  , digestive-functors       >= 0.7      && < 0.9
-                 , hspec                    >= 2.2      && < 2.5
-                 , hspec-core               >= 2.2      && < 2.5
+                 , hspec                    >= 2.2      && < 2.6
+                 , hspec-core               >= 2.2      && < 2.6
                  , HUnit                    >= 1.5      && < 1.7
                  , hxt                      >= 9.3      && < 9.4
                  , HandsomeSoup             >= 0.3      && < 0.5
                  , lens                     >= 3.10     && < 5
                  , mtl                      >= 2        && < 3
-                 , snap                     >= 1.0      && < 1.1
-                 , snap-core                >= 1.0      && < 1.1
+                 , snap                     >= 1.0      && < 1.2
+                 , snap-core                >= 1.0      && < 1.2
                  , text                     >= 0.11     && < 1.3
                  , transformers             >= 0.3      && < 0.6
 

--- a/hspec-snap.cabal
+++ b/hspec-snap.cabal
@@ -18,7 +18,7 @@ library
   exposed-modules:
         Test.Hspec.Snap
   hs-source-dirs:  src
-  build-depends:   base                     >= 4.6      && < 4.10
+  build-depends:   base                     >= 4.6      && < 4.11
                  , aeson                    >= 0.6      && < 1.3
                  , bytestring               >= 0.9      && < 0.11
                  , containers               >= 0.4      && < 0.6

--- a/hspec-snap.cabal
+++ b/hspec-snap.cabal
@@ -18,13 +18,13 @@ library
   exposed-modules:
         Test.Hspec.Snap
   hs-source-dirs:  src
-  build-depends:   base                     >= 4.6      && < 4.12
-                 , aeson                    >= 0.6      && < 1.4
+  build-depends:   base                     >= 4.6      && < 4.13
+                 , aeson                    >= 0.6      && < 1.5
                  , bytestring               >= 0.9      && < 0.11
-                 , containers               >= 0.4      && < 0.6
+                 , containers               >= 0.4      && < 0.7
                  , digestive-functors       >= 0.7      && < 0.9
-                 , hspec                    >= 2.2      && < 2.6
-                 , hspec-core               >= 2.2      && < 2.6
+                 , hspec                    >= 2.2      && < 2.8
+                 , hspec-core               >= 2.2      && < 2.8
                  , HUnit                    >= 1.5      && < 1.7
                  , hxt                      >= 9.3      && < 9.4
                  , HandsomeSoup             >= 0.3      && < 0.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,27 +2,29 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-- HUnit-1.5.0.0
-- hspec-2.4.0
-- hspec-core-2.4.0
+- aeson-1.1.2.0
+- HUnit-1.6.0.0
+- hspec-2.4.4
+- hspec-core-2.4.4
 - hspec-expectations-0.8.2
-- hspec-discover-2.4.0
+- hspec-discover-2.4.4
 - http-common-0.8.2.0
-- http-streams-0.8.3.3
+- http-streams-0.8.5.3
 - readable-0.3.1
 - test-framework-smallcheck-0.2
-- openssl-streams-1.2.1.0
+- openssl-streams-1.2.1.3
 - digestive-functors-0.8.2.0
-- snap-1.0.0.1
-- snap-core-1.0.0.0
+- snap-1.0.0.2
+- snap-core-1.0.3.1
 - heist-1.0.1.0
-- map-syntax-0.2.0.1
-- snap-server-1.0.2.2
-- xmlhtml-0.2.3.5
-- io-streams-1.3.5.0
-- io-streams-haproxy-1.0.0.0
-- clock-0.7.1
-- errors-2.1.2
+- map-syntax-0.2.0.2
+- snap-server-1.0.3.1
+- xmlhtml-0.2.5
+- io-streams-1.5.0.1
+- io-streams-haproxy-1.0.0.2
+- clock-0.7.2
+- errors-2.2.2
 - unexceptionalio-0.3.0
+- time-1.6.0.1
 
 resolver: lts-8.14


### PR DESCRIPTION
I've also bumped upper bounds on several other dependencies, and dropped bounds that were redundant between the test suite and main library.