### PR TITLE
build: relax base constraint for Haskell 8.10

### DIFF
--- a/hspec-snap.cabal
+++ b/hspec-snap.cabal
@@ -18,7 +18,7 @@ library
   exposed-modules:
         Test.Hspec.Snap
   hs-source-dirs:  src
-  build-depends:   base                     >= 4.6      && < 4.14
+  build-depends:   base                     >= 4.6      && < 4.15
                  , aeson                    >= 0.6      && < 1.5
                  , bytestring               >= 0.9      && < 0.11
                  , containers               >= 0.4      && < 0.7


### PR DESCRIPTION
Requiring < 4.14 prevents installation of hspec-snap on Haskell 8.10,
which is paired with base 4.14.3.0.

Unlike in 8836518, no other changes are made; I'm not sure what would be
desired for any version bumps, and I don't use Stack.

It might be worth considering looser constraints, or the ^>= operator
instead of using <.